### PR TITLE
Namespace new_resource properties

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'eric.herot@evertrue.com'
 license          'Apache v2.0'
 description      'Installs/Configures storage'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '6.0.1'
+version          '6.0.2'
 
 supports 'ubuntu', '>= 12.04'
 chef_version '~> 12.10'

--- a/resources/format_mount.rb
+++ b/resources/format_mount.rb
@@ -6,10 +6,10 @@ property :fs_type,        String, default: 'ext4'
 property :reserved_space, default: 0
 
 action :run do
-  execute "format #{device_name} as #{fs_type}" do
-    command "mke2fs -j -m#{reserved_space} -F #{device_name} -t #{fs_type}"
+  execute "format #{new_resource.device_name} as #{new_resource.fs_type}" do
+    command "mke2fs -j -m#{new_resource.reserved_space} -F #{new_resource.device_name} -t #{new_resource.fs_type}"
     action :run
-    not_if { `file -s #{device_name}` =~ /filesystem data/ }
+    not_if { `file -s #{new_resource.device_name}` =~ /filesystem data/ }
   end
 
   directory mount_point do


### PR DESCRIPTION
In our configuration, the `fs_type` property was instead calling the `fs_type` helper method [from the users cookbook](https://github.com/chef-cookbooks/users/blob/475c3b79fa493324f47c52c25bfe989bba305845/libraries/helpers.rb#L7). Using `new_resource.fs_type` should prevent the resource from calling global methods and force the correct behavior, [according to the Chef docs](https://docs.chef.io/custom_resources.html)